### PR TITLE
Sync Specific folders

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,11 +10,11 @@ import (
 )
 
 var config struct {
-	Address   string        `short:"a" long:"address" default:"http://localhost:3000" description:"grafana address"`
-	Directory DirectoryFlag `short:"d" long:"directory" default:"./" description:"directory where dashboards live"`
-	Verbose   bool          `short:"v" long:"verbose" description:"displays requests on stderr"`
-
-	Auth struct {
+	Address     string        `short:"a" long:"address" default:"http://localhost:3000" description:"grafana address"`
+	Directory   DirectoryFlag `short:"d" long:"directory" default:"./" description:"directory where dashboards live"`
+	Verbose     bool          `short:"v" long:"verbose" description:"displays requests on stderr"`
+	SyncFolders []string      `long:"sync-folders" short:"f" description:"specific folders to sync"`
+	Auth        struct {
 		Username    string `short:"u" long:"username" description:"basic auth username"`
 		Password    string `short:"p" long:"password" description:"basic auth password"`
 		AccessToken string `long:"access-token" description:"access token to authenticate against grafana"`
@@ -30,6 +30,15 @@ func handleSignals(cancel context.CancelFunc) {
 	<-sigChan
 
 	cancel()
+}
+
+func shouldSyncFolder(syncFolders []string, folder string) bool {
+	for _, f := range syncFolders {
+		if folder == f {
+			return true
+		}
+	}
+	return false
 }
 
 func main() {

--- a/pull.go
+++ b/pull.go
@@ -10,7 +10,6 @@ import (
 )
 
 type pullCommand struct{
-	SyncFolders []string `long:"sync-folders" short:"f" description:"datasource used by the dashboards"`
 }
 
 func (p *pullCommand) Execute(args []string) (err error) {
@@ -31,7 +30,7 @@ func (p *pullCommand) Execute(args []string) (err error) {
 
 	var dashboard map[string]interface{}
 	for _, ref := range refs {
-		if ! shouldSyncFolder(p.SyncFolders, ref.Folder) {
+		if ! shouldSyncFolder(config.SyncFolders, ref.Folder) {
 			fmt.Println("Not syncing folder", ref.Folder)
 			continue
 		}
@@ -55,14 +54,7 @@ func (p *pullCommand) Execute(args []string) (err error) {
 
 	return
 }
-func shouldSyncFolder(syncFolders []string, folder string) bool {
-	for _, f := range(syncFolders) {
-		if folder == f {
-			return true
-		}
-	}
-	return false
-}
+
 
 func eventuallyCreateDirectory(dir string) (err error) {
 	finfo, err := os.Stat(dir)


### PR DESCRIPTION
This PR adds the --sync-folders option to allow syncing of specific folders only. 
It allows excluding default folder too but it seems kind of a hack 
`./grafana-sync --verbose --address https://mygrafana.com --access-token="fillme=" --directory="./test" pull -f Kubernetes --sync-folders ""`
